### PR TITLE
feat: add copy to clipboard functionality in TUI

### DIFF
--- a/alix/clipboard.py
+++ b/alix/clipboard.py
@@ -1,0 +1,96 @@
+import subprocess
+from abc import ABC, abstractmethod
+
+try:
+    import pyperclip
+except ImportError:
+    pyperclip = None
+
+
+#Backend Interface
+class ClipboardBackend(ABC):
+    @abstractmethod
+    def copy(self, text: str) -> bool:
+        """Copy text to clipboard. Return True on success or False otherwise."""
+        ...
+
+
+#pyperclip backend
+class PyperclipBackend(ClipboardBackend):
+    def copy(self, text: str) -> bool:
+        if pyperclip is None:
+            return False
+        try:
+            pyperclip.copy(text)
+            return True
+        except pyperclip.PyperclipException:
+            return False
+
+
+#macos backend
+class MacOSBackend(ClipboardBackend):
+    def copy(self, text: str) -> bool:
+        if platform.system() != "Darwin":
+            return False
+        try:
+            p = subprocess.Popen(["pbcopy"], stdin=subprocess.PIPE)
+            p.communicate(text.encode("utf-8"))
+            return p.returncode == 0
+        except Exception:
+            return False
+
+
+#windows backend
+class WindowsBackend(ClipboardBackend):
+    def copy(self, text: str) -> bool:
+        if platform.system() != "Windows":
+            return False
+        try:
+            p = subprocess.Popen(["clip"], stdin=subprocess.PIPE, shell=True)
+            p.communicate(text.encode("utf-8"))
+            return p.returncode == 0
+        except Exception:
+            return False
+
+
+#linux backend
+class LinuxBackend(ClipboardBackend):
+    def copy(self, text: str) -> bool:
+        if platform.system() != "Linux":
+            return False
+        try:
+            # Try xclip first, then xsel
+            for cmd in [["xclip", "-selection", "clipboard"], ["xsel", "--clipboard", "--input"]]:
+                try:
+                    p = subprocess.Popen(cmd, stdin=subprocess.PIPE)
+                    p.communicate(text.encode("utf-8"))
+                    if p.returncode == 0:
+                        return True
+                except FileNotFoundError:
+                    continue
+            return False
+        except Exception:
+            return False
+
+
+#fallback
+class FallbackBackend(ClipboardBackend):
+    def copy(self, text: str) -> bool:
+        return False
+
+#Clipboard Manager
+class ClipboardManager:
+    def __init__(self):
+        self.backends = [
+            PyperclipBackend(),
+            MacOSBackend(),
+            WindowsBackend(),
+            LinuxBackend(),
+            FallbackBackend(),
+        ]
+
+    def copy(self, text: str) -> bool:
+        for backend in self.backends:
+            if backend.copy(text):
+                return True
+        return False

--- a/alix/clipboard.py
+++ b/alix/clipboard.py
@@ -1,4 +1,5 @@
 import subprocess
+import platform
 from abc import ABC, abstractmethod
 
 try:

--- a/alix/tui.py
+++ b/alix/tui.py
@@ -10,7 +10,7 @@ from alix.storage import AliasStorage
 from alix.models import Alias
 from alix.config import Config
 from alix.shell_integrator import ShellIntegrator  # NEW IMPORT
-
+from alix.clipboard import ClipboardManager
 
 class AddAliasModal(ModalScreen[bool]):
     """Clean modal for adding aliases"""
@@ -466,6 +466,7 @@ class AliasManager(App):
     # MODIFIED: Added 'p' binding for apply all
     BINDINGS = [
         Binding("q", "quit", "Quit", show=True, priority=True),
+        Binding("c", "copy_alias", "Copy", show=True), #copy the alias command to clipboard
         Binding("a", "add_alias", "Add", show=True),
         Binding("e", "edit_alias", "Edit", show=True),
         Binding("d", "delete_alias", "Delete", show=True),
@@ -603,6 +604,19 @@ class AliasManager(App):
                 self.notify("Alias added and applied successfully")
 
         self.push_screen(AddAliasModal(), callback)
+
+    def action_copy_alias(self) -> None:
+        clipboard=ClipboardManager()
+        if self.selected_alias is None:
+            return
+
+        alias_cmd = self.selected_alias.command
+
+        try:
+            clipboard.copy(alias_cmd)
+            self.notify("Alias command copied to clipboard")
+        except:
+            self.notify(f"Unable to copy. Command: {alias_cmd}")
 
     def action_edit_alias(self) -> None:
         if self.selected_alias:

--- a/alix/tui.py
+++ b/alix/tui.py
@@ -404,7 +404,7 @@ class AliasManager(App):
     }
 
     DataTable > .datatable--cursor {
-        background: $secondary 30%;
+        background: $secondary 70%;
     }
 
     DataTable > .datatable--hover {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "click>=8.1.0",
     "rich>=13.0.0",
     "textual>=0.40.0",
+    "pyperclip>=1.11.0",
     "pyyaml>=6.0.0",
 ]
 


### PR DESCRIPTION
## PR Checklist
- [X] Follows single-purpose principle  
- [X] Tests pass locally (if applicable)
- [X] Documentation updated (if needed)

## What does this PR do?
<!-- Brief description -->
Allow users to copy alias commands to clipboard directly from the TUI interface.
Has cross platform clipboard support


## Related Issue
Fixes #31 

## Type of change
- [ ] Bug fix (non-breaking)
- [X] New feature (non-breaking)
- [ ] Configuration change
- [ ] Documentation update
- [x] Setup/Infrastructure

## Testing
<!-- How to test these changes -->