### PR TITLE
Enhance shell detection with macOS support and add config file hints

### DIFF
--- a/alix/shell_integrator.py
+++ b/alix/shell_integrator.py
@@ -1,7 +1,7 @@
 import shutil
 from pathlib import Path
 from datetime import datetime
-from typing import List, Optional
+from typing import Optional
 
 from alix.shell_detector import ShellDetector, ShellType
 from alix.storage import AliasStorage


### PR DESCRIPTION
This pull request enhances the shell detection logic in `alix/shell_detector.py` to provide more accurate and robust identification of the user's current shell, especially on macOS systems. The changes introduce multiple detection strategies, prioritize reliability, and add fallbacks for various environments.

Shell detection improvements:

* Expanded the `detect_current_shell` method to use several detection methods in order of reliability: environment variables, `/etc/passwd`, macOS-specific `dscl` and version checks, shell-specific environment variables, parent process inspection, and the presence of shell config files. This significantly increases the accuracy of shell detection across platforms, especially for macOS users.
* Added a private method `_get_shell_hints_from_configs` to infer the shell type based on the existence of common shell configuration files in the user's home directory.

Code cleanup and minor refactoring:

* Removed unused imports (`List`) from both `alix/shell_detector.py` and `alix/shell_integrator.py` for code cleanliness. [[1]](diffhunk://#diff-1cd818f6d0f9a85a028495243ea7f33136fe0f2b2282a891bf045a65313d4464R5-R8) [[2]](diffhunk://#diff-8c2ca1be63309d53e83c12dbba939f94d74bef97376ec2a8062450fd3f42095cL4-R4)
* Added necessary imports (`subprocess`, `pwd`) to support new detection methods in `alix/shell_detector.py`.