### PR TITLE
test: Add tests for storage module

### DIFF
--- a/alix/models.py
+++ b/alix/models.py
@@ -15,14 +15,14 @@ class UsageRecord:
     """Represents a single usage event of an alias"""
     timestamp: datetime
     context: Optional[str] = None  # Additional context like working directory, shell session, etc.
-    
+
     def to_dict(self) -> dict:
         """Convert usage record to dictionary for storage"""
         return {
             "timestamp": self.timestamp.isoformat(),
             "context": self.context
         }
-    
+
     @classmethod
     def from_dict(cls, data: dict) -> "UsageRecord":
         """Create usage record from dictionary"""
@@ -59,7 +59,7 @@ class Alias:
             "used_count": self.used_count,
             "shell": self.shell,
             "last_used": self.last_used.isoformat() if self.last_used else None,
-            "usage_history": [record.to_dict() for record in self.usage_history]
+            "usage_history": [record.to_dict() for record in self.usage_history],
             "group": self.group
 
         }
@@ -75,18 +75,18 @@ class Alias:
         if "usage_history" in data:
             data["usage_history"] = [UsageRecord.from_dict(record) for record in data["usage_history"]]
         return cls(**data)
-    
+
     def record_usage(self, context: Optional[str] = None) -> None:
         """Record a usage event for this alias"""
         now = datetime.now()
         self.used_count += 1
         self.last_used = now
         self.usage_history.append(UsageRecord(timestamp=now, context=context))
-        
+
         # Keep only last 100 usage records to prevent storage bloat
         if len(self.usage_history) > 100:
             self.usage_history = self.usage_history[-100:]
-    
+
     def get_usage_stats(self) -> Dict[str, any]:
         """Get usage statistics for this alias"""
         if not self.usage_history:
@@ -97,14 +97,14 @@ class Alias:
                 "usage_frequency": 0,
                 "recent_usage": []
             }
-        
+
         # Calculate usage frequency (uses per day since creation)
         days_since_creation = (datetime.now() - self.created_at).days
         usage_frequency = self.used_count / max(days_since_creation, 1)
-        
+
         # Get recent usage (last 10 records)
         recent_usage = self.usage_history[-10:] if len(self.usage_history) > 10 else self.usage_history
-        
+
         return {
             "total_uses": self.used_count,
             "first_used": self.usage_history[0].timestamp if self.usage_history else None,

--- a/alix/storage.py
+++ b/alix/storage.py
@@ -41,13 +41,13 @@ class AliasStorage:
             # Keep only last 10 backups
             self.cleanup_old_backups(keep=10)
             return backup_path
-        except Exception:
+        except Exception:  # pragma: no cover
             return None
 
     def cleanup_old_backups(self, keep: int = 10) -> None:
         """Remove old backups, keeping only the most recent ones"""
         backups = sorted(self.backup_dir.glob("aliases_*.json"))
-        if len(backups) > keep:
+        if len(backups) > keep:  # pragma: no branch
             for backup in backups[:-keep]:
                 backup.unlink()
 
@@ -64,7 +64,7 @@ class AliasStorage:
             except (json.JSONDecodeError, Exception):
                 # If file is corrupted, start fresh but backup old file
                 backup_path = self.storage_path.with_suffix(".corrupted")
-                if self.storage_path.exists():
+                if self.storage_path.exists():  # pragma: no branch
                     self.storage_path.rename(backup_path)
                 self.aliases = {}
 
@@ -117,22 +117,22 @@ class AliasStorage:
             self.load()
             return True
         return False
-    
+
     def track_usage(self, alias_name: str, context: Optional[str] = None) -> None:
         """Track usage of an alias"""
         if alias_name in self.aliases:
             # Update the alias object
             self.aliases[alias_name].record_usage(context)
             self.save()
-            
+
             # Update the usage tracker
             self.usage_tracker.track_alias_usage(alias_name, context)
-    
+
     def get_usage_analytics(self) -> Dict:
         """Get comprehensive usage analytics"""
         aliases = list(self.aliases.values())
         analytics = self.usage_tracker.get_usage_analytics(aliases)
-        
+
         return {
             "total_aliases": analytics.total_aliases,
             "total_uses": analytics.total_uses,
@@ -144,7 +144,7 @@ class AliasStorage:
             "average_usage_per_alias": analytics.average_usage_per_alias,
             "most_productive_aliases": analytics.most_productive_aliases
         }
-      
+
     def get_by_group(self, group_name: str) -> List[Alias]:
         """Get all aliases in a specific group"""
         return [alias for alias in self.aliases.values() if alias.group == group_name]
@@ -165,4 +165,3 @@ class AliasStorage:
             if self.remove(name):
                 count += 1
         return count
-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,14 +21,14 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = [
-
     "pytest-cov>=4.0.0",
     "black>=23.0.0",
     "flake8>=6.0.0",
+    "freezegun>=1.5.5",
 ]
 
 [project.scripts]
 alix = "alix.cli:main"
 
 [tool.pytest.ini_options]
-addopts = "--cov=alix --cov-branch"
+addopts = "--cov=alix --cov-branch --cov-report=term-missing"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+import json
 from datetime import datetime
 from typing import Any, Dict, List
 from unittest.mock import ANY
@@ -16,6 +17,9 @@ def alias() -> Alias:
         tags=["a", "b"],
         shell="zsh",
         created_at=datetime(2025, 10, 24, 16, 34, 21, 653023),
+        last_used=None,
+        usage_history=[],
+        group=None,
     )
 
 
@@ -51,6 +55,7 @@ def porter_data() -> Dict[str, Any]:
                 "used_count": 0,
                 "last_used": None,
                 "usage_history": [],
+                "group": None,
             },
             {
                 "name": "alix-test-echo",
@@ -62,9 +67,35 @@ def porter_data() -> Dict[str, Any]:
                 "used_count": 0,
                 "last_used": None,
                 "usage_history": [],
+                "group": None,
             },
         ],
     }
+
+
+@pytest.fixture
+def storage_file_raw_data() -> str:
+    return """
+    {
+        "alix-test-echo": {
+            "name": "alix-test-echo",
+            "command": "alix test working!",
+            "description": "alix test shortcut",
+            "tags": ["a", "b"],
+            "created_at": "2025-10-24T16:34:21.653023",
+            "used_count": 0,
+            "shell": "zsh",
+            "last_used": null,
+            "usage_history": [],
+            "group": null
+        }
+    }
+    """
+
+
+@pytest.fixture
+def storage_file_data(storage_file_raw_data) -> Dict[str, Any]:
+    return json.loads(storage_file_raw_data)
 
 
 @pytest.fixture
@@ -72,4 +103,3 @@ def shell_file_data() -> str:
     return """
     alias alix-test-echo='alix test working!'
     """
-

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -42,7 +42,9 @@ def test_scan_system__no_aliases(mock_detect_current_shell, mock_find_config_fil
 
 @patch("alix.scanner.subprocess")
 @patch.object(ShellDetector, "detect_current_shell")
-def test_get_active_aliases(mock_detect_current_shell, mock_subprocess, shell_file_data):
+def test_get_active_aliases(
+    mock_detect_current_shell, mock_subprocess, shell_file_data
+):
     mock_detect_current_shell.return_value = ShellType.ZSH
     mock_stdout = f"{shell_file_data}\n{shell_file_data}"
     mock_subprocess.run.return_value.returncode = 0

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1,0 +1,247 @@
+from pathlib import Path
+from unittest.mock import ANY, Mock, mock_open, patch
+
+from freezegun import freeze_time
+
+from alix.storage import AliasStorage
+
+
+@patch.object(AliasStorage, "load")
+@patch("os.mkdir")
+def test_init__default_path(mock_mkdir, mock_load):
+    AliasStorage()
+
+    expected_storage_path = Path.home() / ".alix"
+    expected_backup_path = expected_storage_path / "backups"
+
+    mock_mkdir.assert_any_call(expected_storage_path, ANY)
+    mock_mkdir.assert_any_call(expected_backup_path, ANY)
+    mock_load.assert_called_once()
+
+
+@patch.object(AliasStorage, "load")
+@patch("os.mkdir")
+def test_init__custom_path(mock_mkdir, mock_load):
+    expected_storage_path = Path("/some/path/file.json")
+    expected_backup_path = Path("/some/path/backups")
+
+    AliasStorage(storage_path=expected_storage_path)
+
+    mock_mkdir.assert_any_call(expected_backup_path, ANY)
+    mock_load.assert_called_once()
+
+
+@freeze_time("2025-10-24 21:01:01")
+@patch("os.mkdir")
+@patch("alix.storage.shutil")
+def test_create_backup(mock_shutil, mock_mkdir):
+    storage = AliasStorage()
+    storage.aliases = {"alix-test-echo": "alix test working!"}
+
+    with (
+        patch("pathlib.Path.exists", autospec=True) as mock_exists,
+        patch("pathlib.Path.glob", autospec=True) as mock_glob,
+        patch("pathlib.Path.unlink", autospec=True) as mock_unlink,
+    ):
+        mock_exists.return_value = True
+        mock_glob.return_value = [
+            Path("alias_20251024_200000.json"),
+            Path("alias_20251023_200000.json"),
+            Path("alias_20251022_200000.json"),
+            Path("alias_20251021_200000.json"),
+            Path("alias_20251020_200000.json"),
+            Path("alias_20251019_200000.json"),
+            Path("alias_20251018_200000.json"),
+            Path("alias_20251017_200000.json"),
+            Path("alias_20251016_200000.json"),
+            Path("alias_20251015_200000.json"),
+            Path("alias_20251014_200000.json"),
+        ]
+
+        storage.create_backup()
+
+    mock_shutil.copy2.assert_called_once_with(
+        Path.home() / Path(".alix/aliases.json"),
+        Path.home() / Path(".alix/backups/aliases_20251024_210101.json"),
+    )
+    mock_unlink.assert_called_once_with(Path("alias_20251014_200000.json"))
+
+
+@patch("os.mkdir")
+@patch("alix.storage.shutil")
+def test_create_backup__no_aliases_file(mock_shutil, mock_mkdir):
+    storage = AliasStorage(Path("/tmp/nothing/aliases.json"))
+    storage.aliases = {"alix-test-echo": "alix test working!"}
+
+    storage.create_backup()
+
+    mock_shutil.copy2.assert_not_called()
+
+
+@patch("os.mkdir")
+def test_load(mock_mkdir, storage_file_raw_data, alias):
+    storage = AliasStorage()
+
+    mocked_open = mock_open(read_data=storage_file_raw_data)
+    with patch("alix.storage.open", mocked_open), patch(
+        "pathlib.Path.exists", autospec=True
+    ) as mock_exists:
+        mock_exists.return_value = True
+
+        storage.load()
+
+    assert len(storage.aliases) == 1
+
+    assert storage.aliases["alix-test-echo"] == alias
+
+
+@patch("os.mkdir")
+def test_load__corrupted_file(mock_mkdir):
+    expected_data = '{"alix-test-echo": zzzzzz}'
+    mocked_open = mock_open(read_data=expected_data)
+
+    storage = AliasStorage()
+
+    with patch("alix.storage.open", mocked_open), patch(
+        "pathlib.Path.exists", autospec=True
+    ) as mock_exists, patch("pathlib.Path.rename", autospec=True) as mock_rename:
+        mock_exists.return_value = True
+
+        storage.load()
+
+    assert len(storage.aliases) == 0
+    mock_rename.assert_called_once_with(
+        Path.home() / Path(".alix/aliases.json"),
+        Path.home() / Path(".alix/aliases.corrupted"),
+    )
+
+
+@patch("alix.storage.json")
+@patch("os.mkdir")
+def test_add(mock_mkdir, mock_json, alias, storage_file_data):
+    mocked_open = mock_open()
+    mock_backup = Mock()
+
+    storage = AliasStorage()
+    storage.create_backup = mock_backup
+
+    with patch("alix.storage.open", mocked_open):
+        result = storage.add(alias)
+
+    assert result is True
+    assert storage.aliases["alix-test-echo"] == alias
+    mock_backup.assert_called_once()
+    mock_json.dump.assert_called_once_with(
+        storage_file_data, mocked_open(), indent=2, default=str
+    )
+
+
+@patch("alix.storage.json")
+@patch("os.mkdir")
+def test_add__alias_exists(mock_mkdir, mock_json, alias):
+    mock_backup = Mock()
+
+    storage = AliasStorage()
+    storage.create_backup = mock_backup
+    storage.aliases[alias.name] = alias
+
+    result = storage.add(alias)
+
+    assert result is False
+    assert storage.aliases["alix-test-echo"] == alias
+    mock_backup.assert_not_called()
+    mock_json.dump.assert_not_called()
+
+
+@patch("alix.storage.json")
+@patch("os.mkdir")
+def test_remove(mock_mkdir, mock_json, alias):
+    mocked_open = mock_open()
+    mock_backup = Mock()
+
+    storage = AliasStorage()
+    storage.create_backup = mock_backup
+    storage.aliases[alias.name] = alias
+
+    with patch("alix.storage.open", mocked_open):
+        result = storage.remove(alias.name)
+
+    assert result is True
+    assert "alix-test-echo" not in storage.aliases
+    mock_backup.assert_called_once()
+    mock_json.dump.assert_called_once_with({}, mocked_open(), indent=2, default=str)
+
+
+@patch("alix.storage.json")
+@patch("os.mkdir")
+def test_remove__alias_absent(mock_mkdir, mock_json, alias):
+    mock_backup = Mock()
+
+    storage = AliasStorage()
+    storage.create_backup = mock_backup
+
+    result = storage.remove(alias.name)
+
+    assert result is False
+    assert "alix-test-echo" not in storage.aliases
+    mock_backup.assert_not_called()
+    mock_json.dump.assert_not_called()
+
+
+@patch("os.mkdir")
+def test_get(mock_mkdir, alias):
+    storage = AliasStorage()
+    storage.aliases[alias.name] = alias
+
+    assert storage.get(alias.name) == alias
+
+
+@patch("os.mkdir")
+def test_list_all(mock_mkdir, alias_list):
+    storage = AliasStorage()
+    storage.aliases[alias_list[0].name] = alias_list[0]
+    storage.aliases[alias_list[1].name + "-2"] = alias_list[1]
+
+    list_all = storage.list_all()
+    assert list_all[0] == alias_list[0]
+    assert list_all[1] == alias_list[1]
+
+
+@patch("os.mkdir")
+@patch("alix.storage.shutil")
+def test_restore_latest_backup(mock_shutil, mock_mkdir):
+    with patch("pathlib.Path.glob", autospec=True) as mock_glob:
+        mock_glob.return_value = [
+            Path("alias_20251024_200000.json"),
+            Path("alias_20251023_200000.json"),
+        ]
+        mock_load = Mock()
+
+        storage = AliasStorage()
+        storage.load = mock_load
+
+        result = storage.restore_latest_backup()
+
+    assert result is True
+    mock_load.assert_called_once()
+    mock_shutil.copy2.assert_called_once_with(
+        Path("alias_20251024_200000.json"),
+        Path.home() / Path(".alix/aliases.json"),
+    )
+
+
+@patch("os.mkdir")
+@patch("alix.storage.shutil")
+def test_restore_latest_backup__no_backups(mock_shutil, mock_mkdir):
+    with patch("pathlib.Path.glob", autospec=True) as mock_glob:
+        mock_glob.return_value = []
+        mock_load = Mock()
+
+        storage = AliasStorage()
+        storage.load = mock_load
+
+        result = storage.restore_latest_backup()
+
+    assert result is False
+    mock_load.assert_not_called()
+    mock_shutil.copy2.assert_not_called()


### PR DESCRIPTION
## PR Checklist
- [x] Follows single-purpose principle  
- [x] Tests pass locally (if applicable)
- [x] Documentation updated (if needed)

## What does this PR do?

Add storage modules unit tests and fixtures.
This tests the storage of aliases to/from the alias.json file.
A recent addition added alias usage tracking and groups, so I haven't gotten to coverage on those elements of storage.py yet.

Coverage after tests added:
```
Name                       Stmts   Miss Branch BrPart  Cover   Missing
----------------------------------------------------------------------
alix/__init__.py               1      0      0      0   100%
alix/cli.py                  532    532    190      0     0%   1-853
alix/clipboard.py             66     66     16      0     0%   1-101
alix/config.py                31     31      2      0     0%   1-86
alix/models.py                55      0     10      2    97%   71->73, 75->77
alix/porter.py                50      0     16      0   100%
alix/render.py                66     66     40      0     0%   1-94
alix/scanner.py               45      0     16      0   100%
alix/shell_detector.py       111     91     68      0    11%   40-154, 158-177, 183-194
alix/shell_integrator.py     135    135     32      0     0%   1-244
alix/shell_wrapper.py         63     23     16      4    58%   23, 48->46, 57-62, 91, 116-126, 136-147, 156, 164-167
alix/storage.py              101     13     28      1    83%   109, 123->exit, 150, 154-158, 162-167
alix/tui.py                  356    356     98      0     0%   1-998
alix/usage_tracker.py         92     10     24      5    85%   35-37, 47-48, 89, 97, 166->173, 174-176
----------------------------------------------------------------------
TOTAL                       1704   1323    556     12    20%
```

## Related Issue
Fixes #29

## Type of change
- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Configuration change
- [ ] Documentation update
- [x] Setup/Infrastructure
