### PR TITLE
feat(cli,storage): integrate HistoryManager with undo/redo support

### DIFF
--- a/alix/storage.py
+++ b/alix/storage.py
@@ -6,6 +6,7 @@ from datetime import datetime
 
 from alix.models import Alias, TEST_ALIAS_NAME
 from alix.usage_tracker import UsageTracker
+from alix.history_manager import HistoryManager
 
 
 class AliasStorage:
@@ -21,11 +22,13 @@ class AliasStorage:
             self.storage_path = self.storage_dir / "aliases.json"
             self.storage_dir.mkdir(exist_ok=True)
 
+        self.storage_dir = self.storage_path.parent
         self.backup_dir = self.storage_path.parent / "backups"
         self.backup_dir.mkdir(exist_ok=True)
 
         self.aliases: Dict[str, Alias] = {}
-        self.usage_tracker = UsageTracker(self.storage_path.parent)
+        self.usage_tracker = UsageTracker(self.storage_dir)
+        self.history = HistoryManager(self.storage_dir / "history.json")
         self.load()
 
     def create_backup(self) -> Optional[Path]:
@@ -78,21 +81,26 @@ class AliasStorage:
         with open(self.storage_path, "w") as f:
             json.dump(data, f, indent=2, default=str)
 
-    def add(self, alias: Alias) -> bool:
+    def add(self, alias: Alias, record_history: bool = True) -> bool:
         """Add a new alias, return True if successful"""
         if alias.name in self.aliases:
             return False
         self.create_backup()  # Backup before modification
         self.aliases[alias.name] = alias
         self.save()
+        if record_history:
+            self.history.push({"type": "add", "aliases": [alias.to_dict()]})
         return True
 
-    def remove(self, name: str) -> bool:
+    def remove(self, name: str, record_history: bool = True) -> bool:
         """Remove an alias, return True if it existed"""
         if name in self.aliases:
+            alias_snapshot = self.aliases.get(name)
             self.create_backup()  # Backup before modification
             del self.aliases[name]
             self.save()
+            if record_history and alias_snapshot:
+                self.history.push({"type": "remove", "aliases": [alias_snapshot.to_dict()]})
             return True
         return False
 
@@ -159,10 +167,20 @@ class AliasStorage:
 
     def remove_group(self, group_name: str) -> int:
         """Remove all aliases in a group, return count of removed aliases"""
-        count = 0
         aliases_to_remove = [name for name, alias in self.aliases.items() if alias.group == group_name]
+        if not aliases_to_remove:
+            return 0
+
+        removed_aliases = []
+        count = 0
         for name in aliases_to_remove:
-            if self.remove(name):
+            alias_obj = self.aliases.get(name)
+            if self.remove(name, record_history=False) and alias_obj:
+                removed_aliases.append(alias_obj.to_dict())
                 count += 1
+
+        if removed_aliases:
+            self.history.push({"type": "remove_group", "aliases": removed_aliases})
+
         return count
 

--- a/tests/test_undo_redo.py
+++ b/tests/test_undo_redo.py
@@ -1,0 +1,144 @@
+import pytest
+from datetime import datetime
+
+from alix.models import Alias
+from alix.storage import AliasStorage
+from alix.history_manager import MAX_HISTORY
+
+
+@pytest.fixture
+def temp_storage(tmp_path):
+    """Fixture for temporary storage to avoid file pollution."""
+    storage_path = tmp_path / "aliases.json"
+    storage = AliasStorage(storage_path=storage_path)
+    return storage
+
+
+def test_add_undo_redo(temp_storage):
+    alias = Alias(name="test", command="echo hello")
+    
+    # Add alias
+    assert temp_storage.add(alias, record_history=True)
+    assert len(temp_storage.list_all()) == 1
+    assert len(temp_storage.history.list_undo()) == 1
+    
+    # Undo
+    msg = temp_storage.history.perform_undo(temp_storage)
+    assert "Undid add" in msg
+    assert len(temp_storage.list_all()) == 0
+    assert len(temp_storage.history.list_redo()) == 1
+    
+    # Redo
+    msg = temp_storage.history.perform_redo(temp_storage)
+    assert "Redid add" in msg
+    assert len(temp_storage.list_all()) == 1
+
+
+def test_remove_undo_redo(temp_storage):
+    alias = Alias(name="test", command="echo hi")
+    temp_storage.add(alias, record_history=True)
+    
+    # Remove alias
+    assert temp_storage.remove(alias.name, record_history=True)
+    assert len(temp_storage.list_all()) == 0
+    assert len(temp_storage.history.list_undo()) == 2  # add + remove
+    
+    # Undo remove
+    msg = temp_storage.history.perform_undo(temp_storage)
+    assert "Undid remove" in msg
+    assert len(temp_storage.list_all()) == 1
+    assert len(temp_storage.history.list_redo()) == 1
+    
+    # Redo remove
+    msg = temp_storage.history.perform_redo(temp_storage)
+    assert "Redid remove" in msg
+    assert len(temp_storage.list_all()) == 0
+
+
+def test_remove_group_undo_redo(temp_storage):
+    alias1 = Alias(name="test1", command="echo one", group="test_group")
+    alias2 = Alias(name="test2", command="echo two", group="test_group")
+    temp_storage.add(alias1, record_history=True)
+    temp_storage.add(alias2, record_history=True)
+    
+    # Remove group
+    removed_count = temp_storage.remove_group("test_group")
+    assert removed_count == 2
+    assert len(temp_storage.list_all()) == 0
+    assert len(temp_storage.history.list_undo()) == 3  # add1 + add2 + remove_group
+    
+    # Undo remove group
+    msg = temp_storage.history.perform_undo(temp_storage)
+    assert "Undid remove_group" in msg
+    assert len(temp_storage.list_all()) == 2
+    assert len(temp_storage.history.list_redo()) == 1
+    
+    # Undo add2
+    msg = temp_storage.history.perform_undo(temp_storage)
+    assert "Undid add" in msg
+    assert len(temp_storage.list_all()) == 1
+    
+    # Redo add2
+    msg = temp_storage.history.perform_redo(temp_storage)
+    assert "Redid add" in msg
+    assert len(temp_storage.list_all()) == 2
+
+
+def test_empty_stacks(temp_storage):
+    # Undo on empty
+    msg = temp_storage.history.perform_undo(temp_storage)
+    assert "Nothing to undo." in msg
+    assert len(temp_storage.history.list_redo()) == 0
+    
+    # Redo on empty
+    msg = temp_storage.history.perform_redo(temp_storage)
+    assert "Nothing to redo." in msg
+    assert len(temp_storage.history.list_undo()) == 0
+
+
+def test_max_history_trimming(temp_storage):
+    # Push more than MAX_HISTORY ops
+    for i in range(MAX_HISTORY + 1):
+        alias = Alias(name=f"test{i}", command=f"echo {i}")
+        temp_storage.add(alias, record_history=True)
+    
+    assert len(temp_storage.history.list_undo()) == MAX_HISTORY
+    # Oldest should be trimmed (last one is most recent)
+    assert temp_storage.history.list_undo()[-1]["aliases"][0]["name"] == f"test{MAX_HISTORY}"
+
+
+def test_corrupted_history_file(tmp_path):
+    # Create a temporary history file with invalid JSON
+    history_path = tmp_path / "history.json"
+    history_path.parent.mkdir(exist_ok=True)
+    with open(history_path, 'w') as f:
+        f.write("{invalid json")
+    
+    # Create storage with the corrupted history file
+    storage = AliasStorage(storage_path=tmp_path / "aliases.json")
+    
+    # Verify stacks are empty (reset on corruption)
+    assert len(storage.history.list_undo()) == 0
+    assert len(storage.history.list_redo()) == 0
+    
+    # Undo/redo should not crash
+    msg = storage.history.perform_undo(storage)
+    assert "Nothing to undo." in msg
+
+
+def test_partial_failures(temp_storage):
+    # Add valid alias
+    alias_valid = Alias(name="valid", command="echo ok")
+    temp_storage.add(alias_valid, record_history=True)
+    
+    # Simulate corrupted alias data in history
+    corrupted_op = {
+        "type": "add",
+        "aliases": [{"invalid": "data"}],  # Missing name
+        "timestamp": datetime.now().isoformat()
+    }
+    temp_storage.history.push(corrupted_op)
+    
+    # Undo should handle gracefully
+    msg = temp_storage.history.perform_undo(temp_storage)
+    assert "skipped" in msg.lower()


### PR DESCRIPTION
## PR Checklist
- [x] Follows single-purpose principle  
- [x] Tests pass locally (if applicable)
- [ ] Documentation updated (if needed)

## What does this PR do?
This PR integrates the new HistoryManager into both storage.py and cli.py, enabling undo/redo functionality for alias operations (add, edit, scan, and group removals).

## Related Issue
Fixes #25

## Type of change
- [ ] Bug fix (non-breaking)
- [x] New feature (non-breaking)
- [ ] Configuration change
- [ ] Documentation update
- [ ] Setup/Infrastructure

## Testing
Manual verification performed with real CLI usage.
Also, using the test file `test_undo_redo.py`.


## Usage of added features
```bash
# Add an alias
alix add myalias "echo Hello"

# Undo last operation
alix undo

# Redo last undone operation
alix redo

# Inspect stacks
alix list_undo
alix list_redo
```

## Screenshots for better understanding

<img width="665" height="542" alt="image" src="https://github.com/user-attachments/assets/1a4a5d77-b104-4ca7-9314-99bd19830499" />
<img width="661" height="181" alt="image" src="https://github.com/user-attachments/assets/5653a5b6-4e1c-4a49-818d-d1f10b8faace" />