### PR TITLE
fix: update porter test fixture for group field compatibility

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -51,6 +51,7 @@ def porter_data() -> Dict[str, Any]:
                 "used_count": 0,
                 "last_used": None,
                 "usage_history": [],
+                "group": None,
             },
             {
                 "name": "alix-test-echo",
@@ -62,6 +63,7 @@ def porter_data() -> Dict[str, Any]:
                 "used_count": 0,
                 "last_used": None,
                 "usage_history": [],
+                "group": None,
             },
         ],
     }


### PR DESCRIPTION
## PR Checklist
- [x] Follows single-purpose principle  
- [x] Tests pass locally (if applicable)
- [ ] Documentation updated (if needed)

## What does this PR do?
This PR fixes the failing tests in `test_porter.py` by updating the `porter_data` fixture in `tests/conftest.py` to include the `group` field that was added to the `Alias` model.

## Related Issue
Fixes #61.

## Type of change
- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Configuration change
- [ ] Documentation update
- [ ] Setup/Infrastructure

## Testing
By running pytest in the root directory.

## Screenshots
<img width="701" height="250" alt="image" src="https://github.com/user-attachments/assets/e10b9849-af9b-4a7e-9b76-15b8a25622e7" />
<img width="712" height="454" alt="image" src="https://github.com/user-attachments/assets/09988c7a-ecc4-4669-9bb4-f0348ae2edfa" />