### PR TITLE
fix: CI should fail when there are failing tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,4 +35,3 @@ jobs:
 
       - name: Run tests
         run: alix-venv/bin/pytest --tb=short
-        continue-on-error: true # Don't fail if no tests found TODO: Implement tests and replace this with coverage reporting


### PR DESCRIPTION
## PR Checklist
- [x] Follows single-purpose principle  
- [ ] Tests pass locally (if applicable)
- [ ] Documentation updated (if needed)

## What does this PR do?
This PR alters the CI workflow. It changes the behaviour that the CI should fail when there are failing tests.

## Related Issue
Fixes #63.

## Type of change
- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Configuration change
- [ ] Documentation update
- [x] Setup/Infrastructure

## Testing
In the future PRs if they are any failing tests the CI will fail alerting us before merging the PR.