### PR TITLE
fix: isolate test_list_all to prevent loading real aliases

### DIFF
--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -199,6 +199,7 @@ def test_get(mock_mkdir, alias):
 @patch("os.mkdir")
 def test_list_all(mock_mkdir, alias_list):
     storage = AliasStorage()
+    storage.aliases.clear()  # Clear any loaded aliases for test isolation
     storage.aliases[alias_list[0].name] = alias_list[0]
     storage.aliases[alias_list[1].name + "-2"] = alias_list[1]
 


### PR DESCRIPTION
## PR Checklist
- [x] Follows single-purpose principle  
- [x] Tests pass locally (if applicable)
- [ ] Documentation updated (if needed)

## What does this PR do?
The test_list_all test was failing because it loaded existing aliases from the user's ~/.alix/aliases.json file, causing the test to have more aliases than expected and in an unpredictable order. Added storage.aliases.clear() to ensure the test starts with an empty storage, making it properly isolated. This follows the pattern of other tests that mock the load method, but uses clearing for simplicity. The test now passes consistently.

## Related Issue
Fixes #68.

## Type of change
- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Configuration change
- [ ] Documentation update
- [ ] Setup/Infrastructure

## Testing
By running pytest in the root directory.